### PR TITLE
Fixed unexpected ';' errors and manual's name

### DIFF
--- a/configure
+++ b/configure
@@ -409,7 +409,7 @@ install:
 	install -d \${DESTDIR}\${PREFIX}/bin
 	install -d \${DESTDIR}\${MANDIR}/man1
 	install -c -s -m 755 \${PROG} \${DESTDIR}\${PREFIX}/bin
-	install -c -m 644 om4.1 \${DESTDIR}\${MANDIR}/man1/\${PROG}.1
+	install -c -m 644 m4.1 \${DESTDIR}\${MANDIR}/man1/\${PROG}.1
 
 test:
 	echo "No tests"

--- a/ohash.h
+++ b/ohash.h
@@ -49,7 +49,7 @@ struct ohash {
  * a hashing table index (opaque) to be used in find/insert/remove.
  * The keys are stored at a known position in the client data.
  */
-__BEGIN_DECLS
+#define __BEGIN_DECLS
 void ohash_init(struct ohash *, unsigned, struct ohash_info *);
 void ohash_delete(struct ohash *);
 
@@ -70,5 +70,5 @@ uint32_t ohash_interval(const char *, const char **);
 
 unsigned int ohash_qlookupi(struct ohash *, const char *, const char **);
 unsigned int ohash_qlookup(struct ohash *, const char *);
-__END_DECLS
+#define __END_DECLS
 #endif


### PR DESCRIPTION
Several errors arising from `__BEGIN_DECLS` and `__END_DECLS` in ohash.h were surfacing when attempting a build with `./configure && make`:
```C
cc -DEXTENDED -I. -w -D_GNU_SOURCE   -c -o eval.o eval.c
cc -DEXTENDED -I. -w -D_GNU_SOURCE   -c -o expr.o expr.c
cc -DEXTENDED -I. -w -D_GNU_SOURCE   -c -o look.o look.c
In file included from look.c:46:
./ohash.h:52:14: error: expected ';' before 'void'
   52 | __BEGIN_DECLS
      |              ^
      |              ;
   53 | void ohash_init(struct ohash *, unsigned, struct ohash_info *);
      | ~~~~          
./ohash.h:73:12: error: expected ';' before 'typedef'
   73 | __END_DECLS
      |            ^
      |            ;
make: *** [<builtin>: look.o] Error 1
```

A bit of searching lead me to [Writing C header files](https://www.gnu.org/software/libtool/manual/html_node/C-header-files.html).

And it seems that:
> We used to recommend __P, __BEGIN_DECLS and __END_DECLS. This was bad advice since symbols (even preprocessor macro names) that begin with an underscore are reserved for the use of the compiler.

Hence they were prefixed by a `#define `.

There was also an error in the manual page being copied, it seems that the `make install` attempts to copy a file named `om4.1` which doesn't exist. This was simply fixed by changing that to `m4.1`.